### PR TITLE
Fix scipy.integrate.cumtrapz function call

### DIFF
--- a/kuibit/series.py
+++ b/kuibit/series.py
@@ -888,7 +888,9 @@ class BaseSeries(BaseNumerical):
         passing_x = self.x if dx is None else None
         return type(self)(
             self.x,
-            integrate.cumulative_trapezoid(self.y, x=passing_x, dx=dx, initial=0),
+            integrate.cumulative_trapezoid(
+                self.y, x=passing_x, dx=dx, initial=0
+            ),
             True,
         )
 

--- a/kuibit/series.py
+++ b/kuibit/series.py
@@ -888,7 +888,7 @@ class BaseSeries(BaseNumerical):
         passing_x = self.x if dx is None else None
         return type(self)(
             self.x,
-            integrate.cumtrapz(self.y, x=passing_x, dx=dx, initial=0),
+            integrate.cumulative_trapezoid(self.y, x=passing_x, dx=dx, initial=0),
             True,
         )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3
 
-"""Tests for kuibit
-"""
+"""Tests for kuibit"""

--- a/tests/test_cactus_ascii_utils.py
+++ b/tests/test_cactus_ascii_utils.py
@@ -19,8 +19,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for kuibit.cactus_ascii_utils
-"""
+"""Tests for kuibit.cactus_ascii_utils"""
 import unittest
 
 from kuibit import cactus_ascii_utils as cau

--- a/tests/test_frequencyseries.py
+++ b/tests/test_frequencyseries.py
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for kuibit.frequencyseries
-"""
+"""Tests for kuibit.frequencyseries"""
 
 import unittest
 import warnings

--- a/tests/test_grid_data.py
+++ b/tests/test_grid_data.py
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for kuibit.grid_data
-"""
+"""Tests for kuibit.grid_data"""
 
 import os
 import unittest

--- a/tests/test_grid_data_utils.py
+++ b/tests/test_grid_data_utils.py
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for kuibit.grid_data_utils
-"""
+"""Tests for kuibit.grid_data_utils"""
 
 import unittest
 

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for kuibit.timeseries
-"""
+"""Tests for kuibit.timeseries"""
 
 import os
 import unittest

--- a/tests/test_unitconv.py
+++ b/tests/test_unitconv.py
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for kuibit.unitconv
-"""
+"""Tests for kuibit.unitconv"""
 
 import unittest
 


### PR DESCRIPTION
The pyproject.toml for Kuibit states a minimum scipy version of 1.7.0:

```
scipy = [{ version = "^1.7.0", python = "<3.8" },
         { version = "^1.9.0", python = "<3.9, >3.8" },
         { version = "^1.11.0", python = ">=3.12" }]
```

However, the series.py file uses `scipy.integrate.cumtrapz(...)`. That function was [renamed in scipy v1.6.0](https://docs.scipy.org/doc/scipy-1.6.0/reference/tutorial/integrate.html).

There's only one occurrence of this function call in the Kuibit codebase:

```
$ grep -iR "cumtrapz"
kuibit/series.py:            integrate.cumtrapz(self.y, x=passing_x, dx=dx, initial=0),
```

This PR updates the function call to the new name: `scipy.integrate.cumulative_trapezoid`.