### PR TITLE
Fix reading OpenPMD files with certain mesh names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@
 #### General
 - Minimum version of Python required is now 3.9.
 
+#### Bug fixes
+- Fixed reading OpenPMD files with mesh names that do not conform to the
+  `<basename>_rl<N>` or `<basename>_lev<N>` names (e.g.,
+  `odesolvers_do_substeps`, as reported by Steven Brandt)
+
 ## Version 1.5.2 (2 July 2025)
 (Version 1.5.2 does not really exist. Version 1.5.1 was not correctly published due to a workflow error.)
 

--- a/kuibit/cactus_grid_functions.py
+++ b/kuibit/cactus_grid_functions.py
@@ -1740,19 +1740,18 @@ class AllGridFunctions:
                             mesh_obj,
                         ) in iteration_obj.meshes.items():
                             matched = rx_mesh.match(mesh_name)
-                            if matched is None:
-                                raise RuntimeError(
-                                    f"Could not parse mesh {mesh_name}"
-                                )
-                            mesh_basename = matched.group(1)
-                            for variable_name in mesh_obj:
-                                var_list = self._vars_openpmd_files.setdefault(
-                                    variable_name, set()
-                                )
-                                var_list.add(dir_path)
-                                self._openpmd_mesh_basenames[variable_name] = (
-                                    mesh_basename
-                                )
+                            if matched is not None:
+                                mesh_basename = matched.group(1)
+                                for variable_name in mesh_obj:
+                                    var_list = (
+                                        self._vars_openpmd_files.setdefault(
+                                            variable_name, set()
+                                        )
+                                    )
+                                    var_list.add(dir_path)
+                                    self._openpmd_mesh_basenames[
+                                        variable_name
+                                    ] = mesh_basename
 
         # What pythonize_name_dict does is to make the various variables
         # accessible as attributes, e.g. self.fields.rho


### PR DESCRIPTION
kuibit assumed that the name was `<basename>_rl<N>` or `<basename>_lev<N>` names, but Steven Brandt reported a case with `odesolvers_do_substeps`.

Thanks Steven Brandt for the bug report and for sharing the files.