### PR TITLE
ci: key venv cache by full Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -32,7 +33,7 @@ jobs:
         id: cached-poetry-dependencies
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
The cache key used `matrix.python-version` (e.g. "3.14"), so the cache remained valid across patch upgrades of the runner's Python. When the hosted runner moved to a newer 3.14.x, the cached venv pointed at the old interpreter and Poetry recreated it as empty. 